### PR TITLE
fix: TypeError when mmsi is returned as number from SignalK API

### DIFF
--- a/src/web/assets/scripts/main.mjs
+++ b/src/web/assets/scripts/main.mjs
@@ -915,7 +915,7 @@ function ingestRawVesselData(vessels) {
 			continue;
 		}
 
-		target.mmsi = vessel.mmsi;
+		target.mmsi = String(vessel.mmsi);
 		target.name = vessel.name || `<${vessel.mmsi}>`;
 		target.sog = vessel.navigation?.speedOverGround?.value;
 		target.cog = vessel.navigation?.courseOverGroundTrue?.value;


### PR DESCRIPTION
The SignalK API can return vessel.mmsi as a number rather than a string. This caused "i.startsWith is not a function" errors when the code later called startsWith() on the mmsi value. Fixed by converting mmsi to string during data ingestion.